### PR TITLE
change fallback userconf path to have a "." in it.

### DIFF
--- a/local/api.go
+++ b/local/api.go
@@ -68,7 +68,7 @@ func userHomePath() string {
  */
 func DiscoverUserPaths(settings *api_local.LocalAPISettings) error {
 	homeDir := userHomePath()
-	homeConfDir := path.Join(homeDir, WUNDERTOOLS_PROJECT_CONF_FOLDER)
+	homeConfDir := path.Join(homeDir, "."+WUNDERTOOLS_PROJECT_CONF_FOLDER)
 
 	if _, err := os.Stat(path.Join(homeDir, "Library")); err == nil {
 		// OSX


### PR DESCRIPTION
This is a small patch, that makes the user specific kraut folder, if it exists in a the Users home folder, to start with a ".".  Putting conf there is an old *Nix thing, which will be avoided if at all possible.