### PR TITLE
made local cli settings provider aware

### DIFF
--- a/local/build.go
+++ b/local/build.go
@@ -41,7 +41,7 @@ func LocalBuild(localApi *api_builder.BuilderAPI) {
 
 			log.WithFields(log.Fields{"type": builderSetting.Type, "implementations": builderSetting.Implementations.Order(), "key": key}).Debug("Activate builder from settings")
 
-			localApi.ActivateBuilder(builderSetting.Type, builderSetting.Implementations, builderSetting.Settings)
+			localApi.ActivateBuilder(builderSetting.Type, builderSetting.Implementations, builderSetting.SettingsProvider)
 		}
 
 	}


### PR DESCRIPTION
This patch makes the CLI use the lastest builder approach of passing a SettingsProvider instead of a settings interface{}