### PR TITLE
change urfave/cli source to gopkg.in to fix building in a container

### DIFF
--- a/build/getdeps
+++ b/build/getdeps
@@ -9,7 +9,7 @@ echo "  --> updating go dependencies"
 
 DEPS="golang.org/x/net/context
 github.com/Sirupsen/logrus
-github.com/urfave/cli.v2
+gopkg.in/urfave/cli.v2
 gopkg.in/yaml.v2
 github.com/docker/libcompose
 github.com/Jalle19/upcloud-go-sdk/upcloud/

--- a/main/command.go
+++ b/main/command.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/urfave/cli.v2"
+	"gopkg.in/urfave/cli.v2"
 
 	api_command "github.com/james-nesbitt/kraut-api/operation/command"
 )

--- a/main/main.go
+++ b/main/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/urfave/cli.v2"
+	"gopkg.in/urfave/cli.v2"
 
 	api_command "github.com/james-nesbitt/kraut-api/operation/command"
 	cli_local "github.com/james-nesbitt/kraut-cli/local"

--- a/main/operation.go
+++ b/main/operation.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/urfave/cli.v2"
+	"gopkg.in/urfave/cli.v2"
 
 	api_operation "github.com/james-nesbitt/kraut-api/operation"
 	api_security "github.com/james-nesbitt/kraut-api/operation/security"

--- a/main/property.go
+++ b/main/property.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/urfave/cli.v2"
 	"golang.org/x/net/context"
+	"gopkg.in/urfave/cli.v2"
 
 	api_operation "github.com/james-nesbitt/kraut-api/operation"
 )


### PR DESCRIPTION
using github as a package source for the urfave/cli fails when using v2 of the cli.  Switching to the gopkg.in repo fixes the build.